### PR TITLE
Avoid escaping quotes in quotemarks rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,7 @@
     "indent": [true, "spaces"],
     "only-arrow-functions": [true, "allow-declarations"],
     "ordered-imports": [true, {"import-sources-order": "any", "named-imports-order": "lowercase-last"}],
-    "quotemark": [true, "single"],
+    "quotemark": [true, "single", "avoid-escape"],
     "trailing-comma": [true, {"multiline": "always", "singleline": "never"}],
     "variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore", "allow-pascal-case"]
   }


### PR DESCRIPTION
Mostly enforce single quotes, but if you're using single quotes in the string, like in `'I\'m green, da ba dee'`, you should instead use double quotes: `"I'm green, da ba dee"`.
