### PR TITLE
Disallow prefixing interfaces with “I”

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,7 @@
     "arrow-return-shorthand": [true, "multiline"],
     "import-spacing": [true],
     "indent": [true, "spaces"],
+    "interface-name": [true, "never-prefix"],
     "only-arrow-functions": [true, "allow-declarations"],
     "ordered-imports": [true, {"import-sources-order": "any", "named-imports-order": "lowercase-last"}],
     "quotemark": [true, "single", "avoid-escape"],


### PR DESCRIPTION
According to [the official guidelines][1] from Microsoft, we should “(…) not use ‘I’ as a prefix for interface names”. The default TSLint configuration seems to say otherwise, but personally, I feel like that's a bad idea. Especially when adding types for existing interfaces, this becomes quite tedious since other classes generally don't have that same prefix.

[1]: https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines#names